### PR TITLE
Add Sasl authentification to memcached

### DIFF
--- a/lib/memcached_client.dart
+++ b/lib/memcached_client.dart
@@ -13,6 +13,7 @@ import "dart:convert" show UTF8;
 import 'package:logging/logging.dart';
 import 'package:crypto/crypto.dart';
 
+part 'src/SaslBinaryConnectionFactory.dart';
 part 'src/BinaryConnectionFactory.dart';
 part 'src/MemcachedClient.dart';
 part 'src/TapClient.dart';

--- a/lib/src/SaslBinaryConnectionFactory.dart
+++ b/lib/src/SaslBinaryConnectionFactory.dart
@@ -11,8 +11,8 @@ class SaslBinaryConnectionFactory extends BinaryConnectionFactory {
 
   AuthDescriptor _authDescriptor = null;
 
-  SaslBinaryConnectionFactory([HashAlgorithm hashAlg], {String bucketName, String password})
-      : super(hashAlg) {
+  SaslBinaryConnectionFactory({String bucketName, String password})
+      : super() {
       if (bucketName != null && password != null)
         _authDescriptor = new AuthDescriptor(["PLAIN"], bucketName, password);
   }

--- a/lib/src/SaslBinaryConnectionFactory.dart
+++ b/lib/src/SaslBinaryConnectionFactory.dart
@@ -1,0 +1,24 @@
+//Copyright (C) 2013 Potix Corporation. All Rights Reserved.
+//History: Thu, Mar 21, 2013  02:19:34 PM
+// Author: hernichen
+
+part of memcached_client;
+
+/**
+ * ConnectionFactory for binary protocol with Sasl authentification.
+ */
+class SaslBinaryConnectionFactory extends BinaryConnectionFactory {
+
+  AuthDescriptor _authDescriptor = null;
+
+  SaslBinaryConnectionFactory([HashAlgorithm hashAlg], {String bucketName, String password})
+      : super(hashAlg) {
+      if (bucketName != null && password != null)
+        _authDescriptor = new AuthDescriptor(["PLAIN"], bucketName, password);
+  }
+
+  @override
+  Future<MemcachedNode> createMemcachedNode(SocketAddress saddr) =>
+      BinaryMemcachedNodeImpl.start(saddr, _authDescriptor);
+
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: memcached_client
-version: 0.5.3
+version: 0.5.4
 author: Henri Chen <henrichen@rikulo.org>
 description: A Memcached client library written in Dart language.
 homepage: https://github.com/rikulo/memcached-client

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: memcached_client
-version: 0.5.4
+version: 0.5.5
 author: Henri Chen <henrichen@rikulo.org>
 description: A Memcached client library written in Dart language.
 homepage: https://github.com/rikulo/memcached-client


### PR DESCRIPTION
Needed to connect to a memcached bucket type with Couchbase

```
var binFactory = new SaslBinaryConnectionFactory(bucketName: "Users", password: "123456");
MemcachedClient.connect(saddrs, factory: binFactory);
```
